### PR TITLE
Renaming the screenshot just after taking it

### DIFF
--- a/bash/Custom_Name_Screenshot/README.md
+++ b/bash/Custom_Name_Screenshot/README.md
@@ -1,0 +1,31 @@
+# Screenshot Renaming Script
+
+#### This script captures a screenshot using Flameshot, allows you to rename it, and saves it to a specified directory. You have the option to rename the screenshot using either Zenity or Rofi.
+
+## Requirements
+
+- Flameshot
+- Rofi (for fast input) or Zenity (for GUI input)
+
+## How It Works
+
+1. The script captures a screenshot using Flameshot.
+2. It generates a default name for the screenshot based on the current date and time.
+3. You can rename the screenshot using either:
+   - **Rofi** (lightweight, fast response)
+   - **Zenity** (graphical interface for input, slower but user-friendly)
+
+## Setup
+
+1. **Install the required tools:**
+   - Flameshot: `sudo pacman -S flameshot` (Arch Linux) or `sudo apt install flameshot` (Debian-based)
+   - Rofi (for lightweight input): `sudo pacman -S rofi` or `sudo apt install rofi`
+   - Zenity (for graphical input): `sudo pacman -S zenity` or `sudo apt install zenity`
+2. **Edit the script to define the screenshot directory:**
+   Replace `path/to/your/screenshot_dir` with the actual path where you want to save screenshots.
+
+## Usage
+
+- The script will take a screenshot and prompt you to rename it.
+- If you use Rofi, it will use a lightweight text prompt.
+- If you want to use Zenity for graphical renaming, uncomment the `zenity` line and comment out the `rofi` line.

--- a/bash/Custom_Name_Screenshot/ssCustomName.sh
+++ b/bash/Custom_Name_Screenshot/ssCustomName.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Giving the path for saving screenshot
+screenshot_dir=path/to/your/screenshot_dir
+
+# Taking Screenshot using flameshot and storing it with a default name
+default_name=$(date '+%Y-%m-%d_%H-%M-%S').png
+flameshot gui -p "$screenshot_dir/$default_name"
+
+# Use zenity for GUI
+# new_name=$(zenity --entry --title="Rename Screenshot" --text="Enter new name for the screenshot:" --entry-text="$default_name")
+# Use Rofi for fast response
+new_name=$(rofi -dmenu -p "Enter new name for screenshot:" -theme "$HOME/.config/rofi/todo.rasi" -no-fixed-num-lines <<<"$default_name")
+
+# If the user provided a name, rename the screenshot
+if [ ! -z "$new_name" ]; then
+  # Add the .png extension if it's not provided
+  if [[ "$new_name" != *.png ]]; then
+    new_name="$new_name.png"
+  fi
+  mv "$screenshot_dir/$default_name" "$screenshot_dir/$new_name"
+fi

--- a/bash/Wallpaper_switcher/README.md
+++ b/bash/Wallpaper_switcher/README.md
@@ -1,0 +1,118 @@
+# Wallpaper Management Scripts
+
+A collection of bash scripts for managing and setting wallpapers using rofi as a selection menu. Two variants are provided - one using `feh` and another using `pywal` for wallpaper setting.
+
+## Prerequisites
+
+- `rofi`: For the selection menu interface
+- `feh` (for feh variant) or `pywal` (for pywal variant): For wallpaper setting
+- Bash shell
+
+### Wallpaper Configuration
+
+In both scripts, wallpapers are configured in the following format:
+
+```bash
+wallpapers=(
+  "Display Name|actual_filename.jpg"
+  "Another Wallpaper|wallpaper2.png"
+)
+```
+
+Each entry consists of:
+
+- Display Name: The name shown in the rofi menu
+- Actual Filename: The filename of the wallpaper in your wallpapers directory
+
+## Usage
+
+### Feh Version
+
+```bash
+./wallpaper-feh.sh
+```
+
+- Provides a basic wallpaper selection and setting functionality
+- Includes an additional "Change Wallpaper" option for sequential selection
+- Uses `feh --bg-fill` to set wallpapers
+
+### Pywal Version
+
+```bash
+./wallpaper-pywal.sh
+```
+
+- Simpler implementation with direct wallpaper selection
+- Uses `pywal` to set wallpaper and generate a matching color scheme
+- Automatically updates terminal colors based on the wallpaper
+
+## Features
+
+### Feh Script
+
+- Direct wallpaper selection
+- "Change Wallpaper" option for multiple selections
+- Custom display names for wallpapers
+- Error handling for invalid selections
+
+### Pywal Script
+
+- Direct wallpaper selection
+- Color scheme generation
+- Terminal color theme integration
+- Custom display names for wallpapers
+- Error handling for invalid selections
+
+## Customization
+
+### Rofi Theme
+
+You can customize the appearance of the selection menu by modifying the rofi theme path:
+
+```bash
+-theme "Path/to/your/themeFile"
+```
+
+### Adding Wallpapers
+
+To add new wallpapers:
+
+1. Add the wallpaper file to your wallpapers directory
+2. Add a new entry to the `wallpapers` array in the format:
+   ```bash
+   "Display Name|filename.extension"
+   ```
+
+## Troubleshooting
+
+### Common Issues
+
+1. Script not executing:
+
+   - Check if the script has executable permissions
+   - Verify the shebang line: `#!/bin/bash`
+
+2. Wallpaper not setting:
+
+   - Verify the wallpaper directory path
+   - Check file permissions of wallpapers
+   - Ensure wallpaper filenames match the configuration
+
+3. Rofi menu not appearing:
+   - Verify rofi is installed
+   - Check if the theme file exists and is accessible
+
+## Dependencies
+
+- Bash
+- rofi
+- feh (for feh script) or pywal (for pywal script)
+- Basic Unix utilities (echo, cut)
+
+## License
+
+This project is provided as-is, feel free to modify and distribute according to your needs.
+
+## Contributing
+
+Feel free to submit issues and enhancement requests.

--- a/bash/Wallpaper_switcher/feh_switcher.sh
+++ b/bash/Wallpaper_switcher/feh_switcher.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Directory containing wallpapers
+WALLPAPER_DIR="Path/to/your/wallpapers_Folder"
+
+# List of wallpapers with custom names
+# Format: Custom Name|Actual Filename
+wallpapers=(
+  "Wallpaper_Display_Name|Filename{.png or .jpg}"
+  "Wallpaper_Display_Name|Filename{.png or .jpg}"
+)
+
+# Generate rofi menu options
+options=""
+for entry in "${wallpapers[@]}"; do
+  name=$(echo "$entry" | cut -d'|' -f1)
+  file=$(echo "$entry" | cut -d'|' -f2)
+  options+="$name\n"
+done
+
+# Show the rofi menu with the custom theme and get the selected option
+selected=$(echo -e "$options" | rofi -dmenu -p "Select wallpaper:" -theme "Path/to/your/themeFile")
+
+# Check if the selected option is 'Change Wallpaper'
+if [ "$selected" == "Change Wallpaper" ]; then
+  rofi -dmenu -p "Select wallpaper to apply:" -theme "Path/to/your/themeFile" | while read -r wallpaper_name; do
+    # Find the corresponding file for the selected wallpaper
+    selected_file=""
+    for entry in "${wallpapers[@]}"; do
+      name=$(echo "$entry" | cut -d'|' -f1)
+      file=$(echo "$entry" | cut -d'|' -f2)
+      if [ "$wallpaper_name" == "$name" ]; then
+        selected_file="$WALLPAPER_DIR/$file"
+        break
+      fi
+    done
+
+    # Apply the selected wallpaper
+    if [ -n "$selected_file" ]; then
+      feh --bg-fill "$selected_file"
+    else
+      echo "No valid selection."
+    fi
+  done
+else
+  # Find the corresponding file for the selected wallpaper
+  selected_file=""
+  for entry in "${wallpapers[@]}"; do
+    name=$(echo "$entry" | cut -d'|' -f1)
+    file=$(echo "$entry" | cut -d'|' -f2)
+    if [ "$selected" == "$name" ]; then
+      selected_file="$WALLPAPER_DIR/$file"
+      break
+    fi
+  done
+
+  # Apply the selected wallpaper
+  if [ -n "$selected_file" ]; then
+    feh --bg-fill "$selected_file"
+  else
+    echo "No valid selection."
+  fi
+fi

--- a/bash/Wallpaper_switcher/pywal_switcher.sh
+++ b/bash/Wallpaper_switcher/pywal_switcher.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Directory containing wallpapers
+WALLPAPER_DIR="Path/to/your/wallpapers_Folder"
+
+# List of wallpapers with custom names
+# Format: Custom Name|Actual Filename
+wallpapers=(
+  "Wallpaper_Display_Name|Filename{.png or .jpg}"
+  "Wallpaper_Display_Name|Filename{.png or .jpg}"
+)
+
+# Generate rofi menu options
+options=""
+for entry in "${wallpapers[@]}"; do
+  name=$(echo "$entry" | cut -d'|' -f1)
+  file=$(echo "$entry" | cut -d'|' -f2)
+  options+="$name\n"
+done
+
+# Show the rofi menu with the custom theme and get the selected option
+selected=$(echo -e "$options" | rofi -dmenu -p "Select wallpaper:" -theme "Path/to/your/themeFile")
+
+# Find the corresponding file for the selected wallpaper
+selected_file=""
+for entry in "${wallpapers[@]}"; do
+  name=$(echo "$entry" | cut -d'|' -f1)
+  file=$(echo "$entry" | cut -d'|' -f2)
+  if [ "$selected" == "$name" ]; then
+    selected_file="$WALLPAPER_DIR/$file"
+    break
+  fi
+done
+
+# Apply the selected wallpaper
+if [ -n "$selected_file" ]; then
+  wal -i "$selected_file"
+else
+  echo "No valid selection."
+fi


### PR DESCRIPTION
Linux users who work mainly in the terminal rarely open file managers, making it hard to preview or organize screenshots. So this simple script lets users rename screenshots immediately after capture, improving organization and making them easier to manage directly from the terminal