### PR TITLE
Add 0x0 File Hosting Wrapper Script

### DIFF
--- a/bash/0x0-WrapperScript/0x0
+++ b/bash/0x0-WrapperScript/0x0
@@ -1,0 +1,127 @@
+#!/bin/sh
+#####################    [  0x0  [  script for file hosting  ]    #################
+#
+#
+#  █████╗ ███████╗██╗  ██╗██╗███████╗██╗  ██╗      ██╗  ██╗██╗   ██╗███████╗
+# ██╔══██╗██╔════╝██║  ██║██║██╔════╝██║  ██║      ██║ ██╔╝██║   ██║██╔════╝
+# ███████║███████╗███████║██║███████╗███████║█████╗█████╔╝ ██║   ██║███████╗
+# ██╔══██║╚════██║██╔══██║██║╚════██║██╔══██║╚════╝██╔═██╗ ██║   ██║╚════██║
+# ██║  ██║███████║██║  ██║██║███████║██║  ██║      ██║  ██╗╚██████╔╝███████║
+# ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚═╝  ╚═╝      ╚═╝  ╚═╝ ╚═════╝ ╚══════╝
+#
+#                                         Gmail: ashish.kus2408@gmail.com
+##################################################################################
+
+# File hosting and URL shortening service.
+# File URLs are valid for at least 30 days and up to a year (see below).
+# Shortened URLs do not expire.
+# Maximum file size: 512.0 MiB
+# Blocked file types: application/x-dosexec, application/x-executable, 
+#                     application/x-hdf5, application/java-archive,
+#                     Android APKs and system images.
+################ [ FOR MORE INFO VISIT: https://0x0.st/  ] ########################
+RED='\033[1;31m'
+CLEAR='\033[0m'
+
+  help()
+  {
+    echo -e "  0x0: File hosting and URL shortening service.
+             File URLs are valid for at least 30 days and up to a year.
+             Shortened URLs do not expire.
+             Maximum file size: 512.0 MiB
+             Blocked file types: application/x-dosexec, application/x-executable, 
+                                 application/x-hdf5, application/java-archive."
+     echo -e "              \033[1;35m USE 0x0 <path_of_file>"
+     echo -e "                      or"
+     echo -e "             USE 0x0 <URL_to_be_shortened>\033[0m"
+     echo -e "\n\033[1;31m -> \033[0m if you are trying to sorten an URL this function is not yet added"
+     echo -e "     FOR MORE INFO VISIT:\033[1;34m https://0x0.st/ \033[0m"
+     echo
+  }
+
+if [ $# -eq 0 ]; then
+   echo -e  "$RED  No file provided $CLEAR"
+   help
+elif [ $# -eq 1 ]; then 
+  while test $# -eq 1
+  do
+       case "$1" in
+           -h)  help
+               ;;
+           --help) help
+               ;;
+                *)    
+                     URL="https://0x0.st"
+                     FILE=$1
+                     if [ ! -f "$FILE" ]; then
+                       echo -e "  \033[0;31mFile ${FILE} not found\033[0m"
+                       help
+                       exit 1
+                     else
+                       RESPONSE=$(curl -# -F "file=@${FILE}" "${URL}")
+                       echo -e "${RESPONSE}" | wl-copy 
+                       echo -e "\n\033[0;32m${RESPONSE}\033[0;36m  copied\033[0m\n"
+                     fi
+               ;;
+       esac
+        shift
+  done
+else
+  help
+fi
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+  

--- a/bash/0x0-WrapperScript/README.md
+++ b/bash/0x0-WrapperScript/README.md
@@ -1,0 +1,63 @@
+
+# 0x0 Wrapper Script
+
+A lightweight shell wrapper script for uploading files to [0x0.st](https://0x0.st/) for temporary file hosting and URL shortening. This script automates file uploads, generates a URL, and copies it directly to your clipboard using `wl-copy`. 
+
+**Note:** This script does not yet support URL shortening. 
+
+## Features
+- Upload files to [0x0.st](https://0x0.st/) with ease.
+- Automatically copies the resulting file URL to your clipboard.
+- Supports files up to 512 MiB in size.
+- Prevents upload of specific blocked file types.
+
+## Requirements
+- `curl`: Used to upload files to the 0x0.st service.
+- `wl-copy`: Automatically copies the generated URL to the clipboard (used for Wayland; if on X11, replace `wl-copy` with `xclip` or an equivalent tool).
+
+## Usage
+```bash
+0x0 <path_to_file>
+```
+
+### Options
+- `-h` or `--help`: Displays usage information and guidelines.
+
+### Example
+```bash
+0x0 my_document.pdf
+```
+
+### Output
+Upon a successful upload, the script outputs the file’s URL and copies it to your clipboard:
+```bash
+https://0x0.st/abc123.pdf  copied
+```
+
+## Installation
+1. Save the script to a file, e.g., `0x0.sh`.
+2. Make the script executable:
+   ```bash
+   chmod +x 0x0.sh
+   ```
+3. Move it to a directory in your PATH, such as `/usr/local/bin`:
+   ```bash
+   sudo mv 0x0.sh /usr/local/bin/0x0
+   ```
+
+## Blocked File Types
+The following file types are not supported by 0x0.st and will be blocked:
+- `application/x-dosexec`
+- `application/x-executable`
+- `application/x-hdf5`
+- `application/java-archive`
+- Android APKs and system images
+
+## Notes
+- Uploaded files are available for at least 30 days and can last up to a year, while shortened URLs (when supported) do not expire.
+
+
+### License
+This script is open-source and provided as-is. Use it responsibly and refer to [0x0.st's website](https://0x0.st/) for more details about terms of use. 
+
+


### PR DESCRIPTION
This PR adds a shell wrapper script for uploading files to the 0x0.st file hosting service. The script streamlines file uploads by generating a URL, copying it to the clipboard via wl-copy, and providing user-friendly feedback.