### PR TITLE
Just configure the plugin in Kargos to add a plasmoid to your KDE panel, and enjoy real-time updates and handy utilities.

### DIFF
--- a/Kargos-plugins/README.md
+++ b/Kargos-plugins/README.md
@@ -1,0 +1,77 @@
+```markdown
+# Kargos Plugins Collection
+
+This repository contains a collection of custom plugins for [Kargos](https://github.com/lipido/kargos), a KDE Plasma port of the Argos and BitBar plugin formats, enabling easy creation of custom plasmoids. Each plugin here is designed to provide practical utilities and dynamic system information right on your KDE panel.
+
+## Features
+
+- **CPU Monitoring**: Displays real-time CPU usage and load with color-coded thresholds.
+- **Memory Usage**: Shows available memory and usage percentage.
+- **Disk Usage**: Monitors specified partitions and alerts based on usage levels.
+- **Weather Updates**: Fetches current weather information using `curl` and a weather API.
+- **RSS Feed Reader**: Continuously rotates through headlines from favorite RSS feeds, inspired by KNewsTicker.
+- **Network Status**: Displays Wi-Fi strength, IP addresses, and network connectivity details.
+- **Battery Status**: Shows current battery charge level and charging status.
+- **Volume Control**: Adds quick volume adjustment and mute options.
+
+## Installation
+
+1. **Install Kargos**:
+   - Clone the repository:
+     ```bash
+     git clone https://github.com/lipido/kargos.git
+     cd kargos
+     kpackagetool5 -t Plasma/Applet --install plasmoid
+     ```
+
+   - Alternatively, install Kargos from KDE's widget store by searching for "kargos".
+
+2. **Add Plugins**:
+   - Clone this repository:
+     ```bash
+     git clone https://github.com/yourusername/kargos-plugins.git
+     cd kargos-plugins
+     ```
+   - Copy desired plugins to your Kargos config directory:
+     ```bash
+     cp plugins/*.sh ~/.config/kargos/
+     chmod +x ~/.config/kargos/*.sh
+     ```
+
+3. **Configure the Kargos Widget**:
+   - Add a Kargos widget to your KDE panel and specify the path of the plugin script in the Kargos settings panel.
+
+## Plugin Examples
+
+### CPU Monitor Plugin (`cpu-monitor.5s.sh`)
+This plugin displays current CPU usage, updating every 5 seconds. It color-codes usage levels based on threshold settings:
+```bash
+#!/bin/bash
+echo "CPU: $(grep 'cpu ' /proc/stat | awk '{print int(($2+$4)*100/($2+$4+$5))}')% | color=blue"
+```
+
+### RSS Reader Plugin (`rss-reader.60s.sh`)
+Displays headlines from an RSS feed, refreshing every 60 seconds. Useful for tracking news without switching apps.
+```bash
+#!/bin/bash
+curl -s "https://rss.cnn.com/rss/edition.rss" | grep "<title>" | head -n 5 | sed 's/<[^>]*>//g'
+```
+
+### Weather Plugin (`weather.30m.sh`)
+Fetches and displays current weather info from an API, refreshing every 30 minutes.
+```bash
+#!/bin/bash
+LOCATION="your-city"
+API_KEY="your-api-key"
+curl -s "https://api.openweathermap.org/data/2.5/weather?q=$LOCATION&appid=$API_KEY" \
+| jq -r '.weather[0].description + " " + (.main.temp - 273.15 | tostring) + "°C"'
+```
+
+## Customization
+
+Each plugin script is easily configurable. Modify refresh intervals by renaming files (e.g., `plugin.5s.sh` to `plugin.10m.sh`). Add new functionalities by editing the `echo` statements, and change colors or icons based on your preferences.
+
+## License
+
+This project is licensed under the MIT License.
+```

--- a/Kargos-plugins/cpu.sh
+++ b/Kargos-plugins/cpu.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+CPU=$(top -bn1 | grep "Cpu(s)" |  sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | bc -l ) 
+USES=$(echo "100 - $CPU"|bc -l) 
+printf ' CPU: %04.1f%%' "$USES"

--- a/Kargos-plugins/memory.sh
+++ b/Kargos-plugins/memory.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+GI=1073741824
+USED=`free -b | grep 'Mem:' | awk '{print \$3}'`
+USEDG=$(echo "scale=2; $USED/$GI" | bc)
+TOTAL=`free -b | grep 'Mem:' | awk '{print \$2}'`
+TOTALG=$(echo "scale=2; $TOTAL/$GI" | bc)
+echo " MEM $USEDG / $TOTALG "

--- a/Kargos-plugins/powerMoniter.sh
+++ b/Kargos-plugins/powerMoniter.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+AC=$(cat /sys/class/power_supply/AC/online)            # whether ac power connected ot not
+if [ $AC -eq 1 ]; then
+  ONLINE="⚡"
+else
+  ONLINE="  "
+fi
+CAPACITY=$(cat /sys/class/power_supply/BAT0/capacity)   #battery percentage
+#            -10 -20 -30 -40 -50 -60 -70 -80 -90  -100 100 
+BATTERYICON=( "" "" "" "" "" "" "" "" "" "" "" )
+FINAL=" $CAPACITY% ${BATTERYICON[$CAPACITY/10]} $ONLINE"
+echo "$FINAL"
+
+


### PR DESCRIPTION
This contains custom plugins for [Kargos](https://github.com/lipido/kargos), a KDE Plasma port of GNOME's Argos and OSX's BitBar for creating custom plasmoids. Each plugin is a simple executable script with useful features like CPU monitoring, weather updates, and RSS feed reading.